### PR TITLE
feat: add header and tagline fields

### DIFF
--- a/premium_bond_checker/client.py
+++ b/premium_bond_checker/client.py
@@ -17,6 +17,8 @@ class Result:
     won: bool
     holder_number: str
     bond_period: str
+    header: str
+    tagline: str
 
 
 class CheckResult:
@@ -74,4 +76,6 @@ class Client:
             raise InvalidHolderNumberException(f"{holder_number} is an invalid number")
 
         won = json["status"] == "win"
-        return Result(won, holder_number, bond_period)
+        header = json["header"]
+        tagline = json["tagline"]
+        return Result(won, holder_number, bond_period, header, tagline)

--- a/premium_bond_checker/test_script.py
+++ b/premium_bond_checker/test_script.py
@@ -22,3 +22,8 @@ if __name__ == "__main__":
 
     result = client.check(premium_bond_number)
     print(f"Winning: {result.has_won()}")
+
+    result_this_month = client.check_this_month(premium_bond_number)
+    print(f"This Month Winning: {result_this_month.won}")
+    print(f"This Month Header: {result_this_month.header}")
+    print(f"This Month Tagline: {result_this_month.tagline}")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,24 +13,24 @@ class TestCheckResult(unittest.TestCase):
 
     def test_has_won_single(self):
         check_result = CheckResult()
-        check_result.add_result(Result(True, "abc1", BondPeriod.THIS_MONTH))
+        check_result.add_result(Result(True, "abc1", BondPeriod.THIS_MONTH, "You won", "£xx"))
         self.assertTrue(check_result.has_won())
 
     def test_has_won_mixed(self):
         check_result = CheckResult()
-        check_result.add_result(Result(True, "abc1", BondPeriod.THIS_MONTH))
-        check_result.add_result(Result(False, "abc2", BondPeriod.LAST_SIX_MONTHS))
+        check_result.add_result(Result(True, "abc1", BondPeriod.THIS_MONTH, "You won", "£xx"))
+        check_result.add_result(Result(False, "abc2", BondPeriod.LAST_SIX_MONTHS, "You didn't win", "Good luck next month"))
         self.assertTrue(check_result.has_won())
 
     def test_has_won_single_false(self):
         check_result = CheckResult()
-        check_result.add_result(Result(False, "abc1", BondPeriod.THIS_MONTH))
+        check_result.add_result(Result(False, "abc1", BondPeriod.THIS_MONTH, "You didn't win", "Good luck next month"))
         self.assertFalse(check_result.has_won())
 
     def test_has_won_mixed_false(self):
         check_result = CheckResult()
-        check_result.add_result(Result(False, "abc1", BondPeriod.THIS_MONTH))
-        check_result.add_result(Result(False, "abc2", BondPeriod.LAST_SIX_MONTHS))
+        check_result.add_result(Result(False, "abc1", BondPeriod.THIS_MONTH, "You didn't win", "Good luck next month"))
+        check_result.add_result(Result(False, "abc2", BondPeriod.LAST_SIX_MONTHS, "You didn't win", "Good luck next month"))
         self.assertFalse(check_result.has_won())
 
 
@@ -54,6 +54,8 @@ class ClientTest(unittest.TestCase):
         result = client.check_this_month("abcd")
 
         self.assertFalse(result.won)
+        self.assertEqual(result.header, "Sorry you didn't win", "header should be 'Sorry you didn't win'")
+        self.assertEqual(result.tagline, "Good luck next month", "tagline should be 'Good luck next month'")
 
     @responses.activate
     def test_check_this_month_invalid_holder_number(self):


### PR DESCRIPTION
Add header and tagline fields in order to use this information in the Home Assistant plugin ([related PR](https://github.com/inverse/home-assistant-premium-bond-checker-component/pull/4))

![image](https://github.com/user-attachments/assets/557d3712-fab0-4282-9970-2891933ff525)
